### PR TITLE
增加了批量指定baseapi，增加自定义api路径的功能

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -1226,9 +1226,9 @@
                                 <option value="paths">路径</option>
                             </select>
                         </div>
-                        <div class="test-controls">
+                        <div class="test-controls" style="flex-direction: column; align-items: flex-start; gap: 8px;">
                             <label style="display: flex; align-items: center;">Base API路径:</label>
-                            <input type="text" id="baseApiPath" placeholder="/api 或 /prod-api" style="flex: 1; padding: 8px; border-radius: 6px; background: rgba(0, 0, 0, 0.5); color: #fff; border: 1px solid #444; font-size: 12px;">
+                            <textarea id="baseApiPath" placeholder="输入Base API路径，每行一个路径&#10;例如：&#10;prod-api/v1/common&#10;prod-api/v1/base&#10;prod-api/v1/sys" style="width: 100%; padding: 10px; border-radius: 6px; background: rgba(0, 0, 0, 0.5); color: #fff; border: 1px solid #444; font-size: 12px; min-height: 80px; max-height: 120px; resize: vertical; font-family: monospace; line-height: 1.4;"></textarea>
                         </div>
                         <div class="test-controls">
                             <label style="display: flex; align-items: center;">并发数:</label>
@@ -1236,6 +1236,15 @@
                             <label style="display: flex; align-items: center;">超时:</label>
                             <input type="number" id="apiTimeout" value="5" min="1" max="300" style="flex: 1; padding: 8px; border-radius: 6px; background: rgba(0, 0, 0, 0.5); color: #fff; border: 1px solid #444; font-size: 12px; -moz-appearance: textfield; appearance: textfield;">
                             <span style="font-size: 12px; color: #ccc; display: flex; align-items: center;">秒</span>
+                        </div>
+                                                                           <div class="test-controls" style="flex-direction: column; align-items: flex-start; gap: 8px;">
+                            <div style="display: flex; gap: 8px; align-items: center;">
+                                <label style="display: flex; align-items: center;">自定义API路径:</label>
+                                <button id="addCustomApiBtn" class="action-button" style="padding: 6px 12px; font-size: 12px; min-width: 50px; height: fit-content; width: auto; margin: 0;">
+                                    <span class="text">添加</span>
+                                </button>
+                            </div>
+                            <textarea id="customApiPaths" placeholder="输入自定义API路径，每行一个路径" style="width: 100%; padding: 10px; border-radius: 6px; background: rgba(0, 0, 0, 0.5); color: #fff; border: 1px solid #444; font-size: 12px; min-height: 60px; max-height: 120px; resize: vertical; font-family: monospace; line-height: 1.4;"></textarea>
                         </div>
                         <button id="batchRequestBtn" class="action-button">
                             <span class="text">批量请求测试</span>

--- a/src/api/TestWindow.js
+++ b/src/api/TestWindow.js
@@ -14,7 +14,7 @@ class TestWindow {
     }
 
     // 创建测试窗口
-    async createTestWindow(categoryKey, items, method, concurrency = 8, timeout = 5000, cookieSetting = '', customBaseApiPath = '') {
+    async createTestWindow(categoryKey, items, method, concurrency = 8, timeout = 5000, cookieSetting = '', customBaseApiPaths = []) {
         let baseUrl = '';
         try {
             const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
@@ -35,7 +35,7 @@ class TestWindow {
             timeout: timeout,
             baseUrl: baseUrl,
             cookieSetting: cookieSetting,
-            customBaseApiPath: customBaseApiPath
+            customBaseApiPaths: customBaseApiPaths
         };
 
         // 将配置保存到chrome.storage，供测试窗口读取

--- a/src/core/SRCMiner.js
+++ b/src/core/SRCMiner.js
@@ -134,6 +134,12 @@ class SRCMiner {
             batchRequestBtn.addEventListener('click', () => this.batchRequestTest());
         }
         
+        // 添加自定义API路径按钮
+        const addCustomApiBtn = document.getElementById('addCustomApiBtn');
+        if (addCustomApiBtn) {
+            addCustomApiBtn.addEventListener('click', () => this.addCustomApiPaths());
+        }
+        
         // 模态框关闭按钮
         const closeModalBtn = document.getElementById('closeModalBtn');
         if (closeModalBtn) {
@@ -296,6 +302,7 @@ class SRCMiner {
         
         // 添加有数据的分类
         const categories = [
+            { key: 'customApis', title: '🔧 自定义API路径' },
             { key: 'absoluteApis', title: '🔗 绝对路径API' },
             { key: 'relativeApis', title: '📁 相对路径API' },
             { key: 'jsFiles', title: '📜 JS文件' },
@@ -951,7 +958,7 @@ class SRCMiner {
         
         const mergedResults = {};
         const categories = [
-            'absoluteApis', 'relativeApis', 'modulePaths', 'domains', 'urls', 
+            'customApis', 'absoluteApis', 'relativeApis', 'modulePaths', 'domains', 'urls', 
             'images', 'jsFiles', 'cssFiles', 'emails', 'phoneNumbers', 
             'ipAddresses', 'sensitiveKeywords', 'comments', 'paths', 
             'parameters', 'credentials', 'cookies', 'idKeys', 'companies', 
@@ -1087,6 +1094,60 @@ class SRCMiner {
             console.error('ApiTester未初始化');
             alert('API测试器未初始化，无法执行测试');
         }
+    }
+    
+        // 添加自定义API路径
+    addCustomApiPaths() {
+        const customApiPathsInput = document.getElementById('customApiPaths');
+        if (!customApiPathsInput) {
+            console.error('找不到自定义API路径输入框');
+            return;
+        }
+        
+        const customApiPaths = customApiPathsInput.value.trim();
+        if (!customApiPaths) {
+            alert('请输入自定义API路径，每行一个路径');
+            return;
+        }
+        
+        // 解析自定义API路径
+        const paths = this.apiTester.parseCustomApiPaths(customApiPaths);
+        if (paths.length === 0) {
+            alert('请输入有效的API路径');
+            return;
+        }
+        
+        // 将自定义API路径添加到扫描结果中
+        if (!this.results.customApis) {
+            this.results.customApis = [];
+        }
+        
+        // 使用Set进行去重
+        const existingSet = new Set(this.results.customApis);
+        let addedCount = 0;
+        
+        paths.forEach(path => {
+            if (!existingSet.has(path)) {
+                this.results.customApis.push(path);
+                existingSet.add(path);
+                addedCount++;
+            }
+        });
+        
+        // 保存结果到存储
+        this.saveResults();
+        
+        // 重新显示结果
+        this.displayResults();
+        
+        // 显示添加成功的提示
+        const message = `成功添加 ${addedCount} 个自定义API路径到扫描结果中:\n${paths.join('\n')}`;
+        alert(message);
+        
+        // 清空输入框
+        customApiPathsInput.value = '';
+        
+        console.log(`✅ 添加了 ${addedCount} 个自定义API路径到扫描结果:`, paths);
     }
     
     // 切换深度扫描 - 使用DeepScanner

--- a/src/main.js
+++ b/src/main.js
@@ -137,6 +137,12 @@ class ILoveYouTranslucent7 {
             batchRequestBtn.addEventListener('click', () => this.batchRequestTest());
         }
         
+        // 添加自定义API路径按钮
+        const addCustomApiBtn = document.getElementById('addCustomApiBtn');
+        if (addCustomApiBtn) {
+            addCustomApiBtn.addEventListener('click', () => this.addCustomApiPaths());
+        }
+        
         // 模态框关闭按钮
         const closeModalBtn = document.getElementById('closeModalBtn');
         if (closeModalBtn) {
@@ -300,6 +306,7 @@ class ILoveYouTranslucent7 {
         
         // 添加有数据的分类
         const categories = [
+            { key: 'customApis', title: '🔧 自定义API路径' },
             { key: 'absoluteApis', title: '🔗 绝对路径API' },
             { key: 'relativeApis', title: '📁 相对路径API' },
             { key: 'jsFiles', title: '📜 JS文件' },
@@ -422,6 +429,60 @@ class ILoveYouTranslucent7 {
     
     async batchRequestTest() {
         return await this.apiTester.batchRequestTest();
+    }
+    
+    // 添加自定义API路径
+    addCustomApiPaths() {
+        const customApiPathsInput = document.getElementById('customApiPaths');
+        if (!customApiPathsInput) {
+            console.error('找不到自定义API路径输入框');
+            return;
+        }
+        
+        const customApiPaths = customApiPathsInput.value.trim();
+        if (!customApiPaths) {
+            alert('请输入自定义API路径，每行一个路径');
+            return;
+        }
+        
+        // 解析自定义API路径
+        const paths = this.apiTester.parseCustomApiPaths(customApiPaths);
+        if (paths.length === 0) {
+            alert('请输入有效的API路径');
+            return;
+        }
+        
+        // 将自定义API路径添加到扫描结果中
+        if (!this.results.customApis) {
+            this.results.customApis = [];
+        }
+        
+        // 使用Set进行去重
+        const existingSet = new Set(this.results.customApis);
+        let addedCount = 0;
+        
+        paths.forEach(path => {
+            if (!existingSet.has(path)) {
+                this.results.customApis.push(path);
+                existingSet.add(path);
+                addedCount++;
+            }
+        });
+        
+        // 保存结果到存储
+        this.saveResults();
+        
+        // 重新显示结果
+        this.displayResults();
+        
+        // 显示添加成功的提示
+        const message = `成功添加 ${addedCount} 个自定义API路径到扫描结果中:\n${paths.join('\n')}`;
+        alert(message);
+        
+        // 清空输入框
+        customApiPathsInput.value = '';
+        
+        console.log(`✅ 添加了 ${addedCount} 个自定义API路径到扫描结果:`, paths);
     }
     
     exportResults() {

--- a/src/ui/DisplayManager.js
+++ b/src/ui/DisplayManager.js
@@ -23,6 +23,7 @@ class DisplayManager {
         
         const resultsDiv = document.getElementById('results');
         const categories = [
+            { key: 'customApis', title: '自定义API路径', icon: '🔧' },
             { key: 'absoluteApis', title: '绝对路径API', icon: '/' },
             { key: 'relativeApis', title: '相对路径API', icon: '~' },
             { key: 'modulePaths', title: '模块路径', icon: './' },
@@ -415,9 +416,39 @@ class DisplayManager {
                 
                 // 获取base API路径配置
                 const baseApiPathInput = document.getElementById('baseApiPath');
-                const customBaseApiPath = baseApiPathInput ? baseApiPathInput.value.trim() : '';
+                const rawBaseApiPaths = baseApiPathInput ? baseApiPathInput.value.trim() : '';
+                const customBaseApiPaths = this.srcMiner.apiTester.normalizeMultipleBaseApiPaths(rawBaseApiPaths);
                 
-                this.srcMiner.apiTester.testSelectedCategory(categoryKey, items, method, concurrency, timeout, customBaseApiPath);
+                // 如果自动添加了"/"前缀，给出提示
+                if (rawBaseApiPaths) {
+                    const originalPaths = rawBaseApiPaths.split('\n').map(p => p.trim()).filter(p => p);
+                    const normalizedPaths = customBaseApiPaths;
+                    
+                    // 检查每个路径是否被修改
+                    originalPaths.forEach((originalPath, index) => {
+                        const normalizedPath = normalizedPaths[index];
+                        if (originalPath && originalPath !== normalizedPath) {
+                            console.log(`🔧 自动为baseapi路径添加"/"前缀: "${originalPath}" -> "${normalizedPath}"`);
+                        }
+                    });
+                    
+                    if (customBaseApiPaths.length > 1) {
+                        console.log(`🔧 检测到 ${customBaseApiPaths.length} 个baseapi路径: ${customBaseApiPaths.join(', ')}`);
+                    }
+                }
+                
+                // 获取自定义API路径配置
+                const customApiPathsInput = document.getElementById('customApiPaths');
+                const customApiPaths = customApiPathsInput ? customApiPathsInput.value.trim() : '';
+                
+                // 如果有自定义API路径，添加到测试列表中
+                if (customApiPaths) {
+                    const customPaths = this.srcMiner.apiTester.parseCustomApiPaths(customApiPaths);
+                    items = this.srcMiner.apiTester.mergeAndDeduplicateItems(items, customPaths);
+                    console.log(`📝 添加了 ${customPaths.length} 个自定义API路径，去重后总计 ${items.length} 个测试项目`);
+                }
+                
+                this.srcMiner.apiTester.testSelectedCategory(categoryKey, items, method, concurrency, timeout, customBaseApiPaths);
             } else {
                 this.showNotification('API测试器未初始化，无法执行测试', 'error');
             }


### PR DESCRIPTION
修复了不带"/"的baseapi路径就会报错的问题，修改指定单个baseapi为指定多个baseapi，增加了自定义来源的api路径，可以从findsomething或者是其他来源导入api路径
api测试界面如下
<img width="500" height="614" alt="image" src="https://github.com/user-attachments/assets/0348eb5b-648f-4182-bdba-c6578008cd51" />
添加多个baseapi测试结果如下
<img width="500" height="614" alt="image" src="https://github.com/user-attachments/assets/267f9633-dd21-4a6b-9bbf-bd5e37dc3910" />
<img width="1509" height="866" alt="image" src="https://github.com/user-attachments/assets/6934441d-f64b-4d02-9a7a-c70794f76b0d" />
从findsomething添加路由
<img width="814" height="614" alt="image" src="https://github.com/user-attachments/assets/7442bee0-3dd2-4eca-8066-82cdf2c0b03f" />
<img width="310" height="240" alt="image" src="https://github.com/user-attachments/assets/874346ea-d28a-495e-9632-4e4b41d97f85" />
添加后需要先到别的界面，比如扫描界面
<img width="485" height="377" alt="image" src="https://github.com/user-attachments/assets/27f3b5b7-7c7c-4f5a-ac38-0a6986183ad8" />
可以看到多了一个自定义的api路径，然后再到api测试界面，就能选择自定义的api路径进行测试了
<img width="500" height="614" alt="image" src="https://github.com/user-attachments/assets/befc21ba-0372-4d91-904d-74372d544fe9" />
<img width="1428" height="776" alt="image" src="https://github.com/user-attachments/assets/c0299ce8-762e-42c5-90e7-8430cafd96a3" />


最后，我非常想完善这两个功能，但是本人代码能力有限，希望大佬们能参考我的想法，最终能将这两个功能整合到项目中，让项目越来越完善，感谢开发者👍👍👍
